### PR TITLE
Use form-validation crate for better error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,6 +991,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "form-validation"
+version = "0.3.1"
+source = "git+https://github.com/pzingg/form-validation?branch=serialize#190e3cdc9f69debe5851bb0d8aa655e13b125249"
+dependencies = [
+ "serde",
+ "uuid",
+]
+
+[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1515,6 +1524,7 @@ dependencies = [
  "dotenv",
  "env_logger",
  "fancy-regex",
+ "form-validation",
  "futures",
  "hmac 0.11.0",
  "lazy_static",
@@ -3096,9 +3106,9 @@ dependencies = [
 
 [[package]]
 name = "validator"
-version = "0.11.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4effc922f18d14f3daf201b1d13c61e5ef62f5975e7d18df381f67badd76cfcd"
+checksum = "6d0f08911ab0fee2c5009580f04615fa868898ee57de10692a45da0c3bcc3e5e"
 dependencies = [
  "idna",
  "lazy_static",
@@ -3112,9 +3122,13 @@ dependencies = [
 
 [[package]]
 name = "validator_types"
-version = "0.11.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add324da7950ac1f76b1c16ce8b5406147953d5d6a2ac1c5da93785f2cfc738b"
+checksum = "ded9d97e1d42327632f5f3bae6403c04886e2de3036261ef42deebd931a6a291"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "version_check"

--- a/jelly/Cargo.toml
+++ b/jelly/Cargo.toml
@@ -11,10 +11,10 @@ opt-level = 3
 
 [dependencies]
 actix-files = { version = "0.6", optional = true }
+actix-rt = "2.7.0"
 actix-service = "2.0"
 actix-session = { version = "0.6.2", features = ["cookie-session"] }
 actix-web = "4.0.1"
-actix-rt = "2.7.0"
 anyhow = "1.0.56"
 async-trait = "0.1.24"
 background-jobs = "0.12.0"
@@ -26,9 +26,12 @@ dotenv = "0.15.0"
 # version determined by pretty_env_logger
 env_logger = { version = "0.7.1", default-features = false, features = ["termcolor", "atty", "humantime"] }
 fancy-regex = "0.8"
+# form-validation = "0.3.1"
+form-validation = { git = "https://github.com/pzingg/form-validation", branch = "serialize" }
 futures = "0.3"
 hmac = "0.11.0"
 lazy_static = "1.4.0"
+lettre = { version="0.10.0-rc.3", optional = true }
 log = "0.4"
 minreq = { version = "2.1.0", features = ["https", "json-using-serde"] }
 notify = { version = "4", optional = true }
@@ -42,21 +45,20 @@ sha2 = "0.9"
 sqlx = { version = "0.5.9", default-features = false, features = ["runtime-actix-rustls", "postgres"] }
 tera = "1.5"
 thiserror = "1.0.30"
-validator = "0.11"
-zxcvbn = "2.2.0"
-lettre = { version="0.10.0-rc.3", optional = true }
 uuid = "0.8"
+validator = "0.14.0"
+zxcvbn = "2.2.0"
 
 [features]
 default = [ ]
-email-smtp = ["lettre"]
 email-mock = []
 email-postmark = [ ]
 email-sendgrid = [ ]
+email-smtp = ["lettre"]
 oauth = ["oauth2"]
+production = ["actix-web/secure-cookies", "djangohashers/with_pbkdf2"]
 static = ["actix-files"]
 template_watcher = ["notify"]
-production = ["actix-web/secure-cookies", "djangohashers/with_pbkdf2"]
 
 [dev-dependencies]
 httpmock = "0.6.5"

--- a/jelly/src/forms.rs
+++ b/jelly/src/forms.rs
@@ -4,7 +4,8 @@
 //! Ex:
 //!
 //! ```rust
-//! use jelly::forms::{EmailField, PasswordField, Validation};
+//! use jelly::forms::{EmailField, PasswordField};
+//! use jelly::forms::validation::{concat_results, Validatable, ValidationErrors};
 //! use serde::Deserialize;
 //!
 //! #[derive(Debug, Default, Deserialize)]
@@ -13,9 +14,14 @@
 //!     pub password: PasswordField
 //! }
 //!
-//! impl Validation for MyForm {
-//!     fn is_valid(&mut self) -> bool {
-//!         self.email.is_valid() && self.password.is_valid()
+//! impl Validatable<String> for MyForm {
+//!     fn validate(&self) -> Result<(), ValidationErrors<String>> {
+//!         concat_results(
+//!             vec![
+//!                 self.email.validate(),
+//!                 self.password.validate(),
+//!             ]
+//!         )
 //!     }
 //! }
 //! ```
@@ -30,7 +36,7 @@ mod email;
 pub use email::EmailField;
 
 mod password;
-pub use password::{PasswordConfig, PasswordField};
+pub use password::{PasswordPolicy, PasswordField};
 
 mod slug;
 pub use slug::SlugField;
@@ -38,11 +44,7 @@ pub use slug::SlugField;
 mod text;
 pub use text::TextField;
 
-/// A trait that Forms can implement for validation. Each field type implements this trait, so you
-/// can simply write your validation method as `field.is_valid()`.
-pub trait Validation {
-    /// Checks if the data held is valid. Should return a bool value.
-    fn is_valid(&mut self) -> bool {
-        false
-    }
-}
+pub use form_validation as validation;
+
+mod validators;
+pub use validators::required_key;

--- a/jelly/src/forms.rs
+++ b/jelly/src/forms.rs
@@ -1,7 +1,7 @@
 //! Implements a set of input types that can be used for Form handling. Mostly modeled after
 //! Django's Form class.
 //!
-//! Ex:
+//! Example:
 //!
 //! ```rust
 //! use jelly::forms::{EmailField, PasswordField};
@@ -36,7 +36,7 @@ mod email;
 pub use email::EmailField;
 
 mod password;
-pub use password::{PasswordPolicy, PasswordField};
+pub use password::{split_inputs, PasswordPolicy, PasswordField};
 
 mod slug;
 pub use slug::SlugField;

--- a/jelly/src/forms/booly.rs
+++ b/jelly/src/forms/booly.rs
@@ -2,7 +2,8 @@ use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt;
 use std::ops::Deref;
 
-use super::Validation;
+use super::validation::{Validatable, Validation, ValidationErrors, Validator};
+use super::validators::required_key;
 
 /// A simple BoolField.
 ///
@@ -11,17 +12,18 @@ use super::Validation;
 #[derive(Debug, Default, Serialize)]
 pub struct BoolField {
     pub value: bool,
-    pub errors: Vec<String>,
+    pub key: String,
 }
 
 impl BoolField {
     pub fn new(value: bool) -> Self {
         Self { value, ..Self::default() }
     }
-}
 
-impl From<bool> for BoolField {
-    fn from(value: bool) -> Self { Self::new(value) }
+    pub fn with_key<S>(mut self, key: S) -> Self where S: Into<String> {
+        self.key = key.into();
+        self
+    }
 }
 
 impl fmt::Display for BoolField {
@@ -47,6 +49,10 @@ impl Deref for BoolField {
     }
 }
 
-impl Validation for BoolField {
-    fn is_valid(&mut self) -> bool { true }
+impl Validatable<String> for BoolField {
+    fn validate(&self) -> Result<(), ValidationErrors<String>> {
+        let v: Validator<bool, String> = Validator::<bool, String>::new()
+            .validation(required_key);
+        v.validate_value(&self.value, &self.key)
+    }
 }

--- a/jelly/src/forms/password.rs
+++ b/jelly/src/forms/password.rs
@@ -1,19 +1,21 @@
 use fancy_regex::Regex;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Deserializer, Serialize};
+use std::collections::HashSet;
 use std::fmt;
+use std::hash::Hash;
 use std::ops::Deref;
 use zxcvbn::zxcvbn;
 
-use super::Validation;
+use super::validation::{concat_results, Validatable, Validation, ValidationError, ValidationErrors, Validator};
+use super::validators::{required_key, required_value};
 
 /// A field for validating password strength. Will also include
 /// hints on how to make a better password.
 #[derive(Debug, Default, Serialize)]
 pub struct PasswordField {
     pub value: String,
-    pub errors: Vec<String>,
-    pub hints: Vec<String>,
+    pub key: String,
 }
 
 impl PasswordField {
@@ -25,80 +27,109 @@ impl PasswordField {
         Self::from_string(value.into())
     }
 
-    pub fn validate_with(&mut self, user_inputs: &[&str], cfg: &PasswordConfig) -> bool {
-        let length_valid = match &cfg.length {
+    pub fn with_key<S>(mut self, key: S) -> Self where S: Into<String> {
+        self.key = key.into();
+        self
+    }
+
+    pub fn validate_with(&self, user_inputs: &[&str], cfg: &PasswordPolicy) -> Result<(), ValidationErrors<String>> {
+        let _ok = self.validate()?;
+
+        let length_validation = match &cfg.length {
             Some(length) => {
                 self.validate_length(length.0, length.1)
             },
-            _ => true,
+            _ => Ok(()),
         };
-        let regex_valid = match &cfg.regex {
-            Some(regex) => self.validate_regex(&regex.regex, &regex.message),
-            _ => true,
+        let regex_validation = match &cfg.regex {
+            Some(regex) => {
+                let re = Regex::new(&regex.pattern).unwrap();
+                self.validate_regex(&re, regex.message.clone())
+            },
+            _ => Ok(()),
         };
-        let strength_valid = match cfg.strength {
-            Some(strength) => self.validate_strength(strength, user_inputs),
-            _ => true,
+        let strength_validation = match &cfg.strength {
+            Some(strength) => self.validate_strength(strength.clone(), user_inputs),
+            _ => Ok(()),
         };
-        length_valid && regex_valid && strength_valid
+
+        concat_results(vec![length_validation, regex_validation, strength_validation])
     }
 
-    pub fn validate_length(&mut self, min_length: usize, max_length: usize) -> bool {
-        match self.value.len() {
-            0 => {
-                self.errors.push("Password cannot be blank.".to_string());
-                false
-            }
-            x if x < min_length => {
-                self.errors.push(format!(
-                    "Password must be at least {} characters.",
-                    min_length
-                ));
-                false
-            }
-            x if x > max_length => {
-                self.errors.push(format!(
-                    "Password must be at most {} characters.",
-                    max_length
-                ));
-                false
-            }
-            _ => true,
-        }
-    }
-
-    pub fn validate_regex(&mut self, regex: &Regex, message: &str) -> bool {
-        if regex.is_match(&self.value).unwrap() {
-            true
+    pub fn validate_confirmation(&self, confirm: &str) -> Result<(), ValidationErrors<String>> {
+        if self.value == confirm {
+            Ok(())
         } else {
-            self.errors.push(message.to_string());
-            false
+            Err(ValidationError::new(self.key.clone(), "PASSWORD_CONFIRMATION")
+                .with_message(move |_| "passwords must match".to_owned())
+                .into())
         }
     }
 
-    pub fn validate_strength(&mut self, strength: u8, user_inputs: &[&str]) -> bool {
+    pub fn validate_length(&self, min_length: usize, max_length: usize) -> Result<(), ValidationErrors<String>> {
+        match self.value.len() {
+            0 => Ok(()), // already validated
+            x if x < min_length =>
+                Err(ValidationError::new(self.key.clone(), "PASSWORD_MIN_LENGTH")
+                .with_message(move |_| format!("must be at least {} characters", min_length))
+                .into()),
+            x if x > max_length =>
+                Err(ValidationError::new(self.key.clone(), "PASSWORD_MAX_LENGTH")
+                .with_message(move |_| format!("must be at most {} characters", max_length))
+                .into()),
+            _ => Ok(()),
+        }
+    }
+
+    pub fn validate_regex(&self, regex: &Regex, message: String) -> Result<(), ValidationErrors<String>> {
+        if regex.is_match(&self.value).unwrap() {
+            Ok(())
+        } else {
+            Err(ValidationError::new(self.key.clone(), "PASSWORD_FORMAT")
+                .with_message(move |_| message.clone())
+                .into())
+        }
+    }
+
+    pub fn validate_strength(&self, strength: PasswordScore, user_inputs: &[&str]) -> Result<(), ValidationErrors<String>> {
         // The unwrap is safe, as it only errors if the
         // password is blank, which we already
         // handle above.
-        let estimate = zxcvbn(&self.value, user_inputs).unwrap();
-        if estimate.score() >= strength {
-            true
+        let words = split_inputs(user_inputs);
+        let estimate = zxcvbn(&self.value,
+            words
+                .iter()
+                .map(|s| s.as_ref())
+                .collect::<Vec<&str>>()
+                .as_slice()).unwrap();
+        if estimate.score() >= strength as u8 {
+            Ok(())
         } else {
+            let mut hints: Vec<String> = Vec::new();
+            let mut warning: Option<String> = None;
             if let Some(feedback) = estimate.feedback() {
-                if let Some(warning) = feedback.warning() {
-                    self.errors.push(format!("{}", warning));
-                } else {
-                    self.errors
-                        .push("Password not strong enough.".to_string());
-                }
-
-                self.hints = feedback
+                hints = feedback
                     .suggestions()
                     .iter()
-                    .map(|s| format!("{}", s))
+                    .map(|s| s.to_string())
                     .collect();
+                warning = feedback
+                    .warning()
+                    .map(|w| w.to_string())
             }
-            false
+            let mut errors: ValidationErrors<String> = ValidationError::new(self.key.clone(), "PASSWORD_STRENGTH")
+                .with_message(move |_| match &warning {
+                    Some(message) => format!("not strong enough. {}", message),
+                    None => "not strong enough".to_owned()
+                    }
+                )
+                .into();
+            if !hints.is_empty() {
+                errors.extend(ValidationError::new(self.key.clone(), "PASSWORD_HINTS")
+                    .with_message(move |_| hints.join("\n"))
+                    .into())
+            }
+            Err(errors)
         }
     }
 }
@@ -130,47 +161,108 @@ impl Deref for PasswordField {
     }
 }
 
-impl Validation for PasswordField {
-    fn is_valid(&mut self) -> bool {
-        self.validate_with(&[], &PasswordConfig::default())
+impl Validatable<String> for PasswordField {
+    fn validate(&self) -> Result<(), ValidationErrors<String>> {
+        let v: Validator<String, String> = Validator::<String, String>::new()
+            .validation(required_key)
+            .validation(required_value);
+        v.validate_value(&self.value, &self.key)
     }
 }
 
-#[derive(Clone, Debug)]
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RegexConfig {
-    regex: Regex,
+    pattern: String,
     message: String,
 }
 
 impl RegexConfig {
     fn new(pattern: &str, message: &str) -> Self {
         RegexConfig {
-            regex: Regex::new(pattern).unwrap(),
-            message: message.to_string(),
+            pattern: pattern.to_owned(),
+            message: message.to_owned(),
         }
     }
 }
 
 lazy_static! {
-    pub static ref DEFAULT_REGEX: RegexConfig = RegexConfig::new(
-        r#"^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[@#$%^&*!?])[-_a-zA-Z0-9@#$%^&*!?]+$"#,
-        "Password must contain upper, lower, number, symbol (@#$%^&*!?)."
+    pub static ref REGEX_ANH: RegexConfig = RegexConfig::new(
+        r#"^[-a-zA-Z0-9]+$"#,
+        "can only contain uppercase, lowercase, numbers, and hyphens."
+    );
+    pub static ref REGEX_ULNS: RegexConfig = RegexConfig::new(
+        r#"^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[-_.@#$%^&*!?])[-_.@#$%^&*!?a-zA-Z0-9]+$"#,
+        "must contain at least one each of uppercase, lowercase, number, and symbol from this set: -_@#$%^&*!?."
     );
 }
 
-#[derive(Clone, Debug)]
-pub struct PasswordConfig {
-    length: Option<(usize, usize)>,
-    regex: Option<RegexConfig>,
-    strength: Option<u8>, // 3 is default
+impl Default for RegexConfig {
+    fn default() -> Self {
+        REGEX_ANH.clone()
+    }
 }
 
-impl Default for PasswordConfig {
+#[repr(u8)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum PasswordScore {
+    TooGuessable = 0,      // risky password. (guesses < 10^3)
+    VeryGuessable = 1,     // protection from throttled online attacks. (guesses < 10^6)
+    SomewhatGuessable = 2, // protection from unthrottled online attacks. (guesses < 10^8)
+    SafelyUnguessable = 3, // moderate protection from offline slow-hash scenario. (guesses < 10^10)
+    VeryUnguessable = 4,   // strong protection from offline slow-hash scenario. (guesses >= 10^10)
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PasswordPolicy {
+    length: Option<(usize, usize)>,
+    regex: Option<RegexConfig>,
+    strength: Option<PasswordScore>,
+}
+
+impl Default for PasswordPolicy {
     fn default() -> Self {
-        PasswordConfig {
+        PasswordPolicy {
             length: Some((8, 255)),
-            regex: Some(DEFAULT_REGEX.clone()),
-            strength: None,
+            regex: Some(REGEX_ANH.clone()),
+            strength: Some(PasswordScore::SafelyUnguessable),
         }
+    }
+}
+
+// DONE: removes all "non-word" chars,
+// DONE: removes words 3 chars or shorter
+// DONE: removes duplicates
+pub fn split_inputs(inputs: &[&str]) -> Vec<String> {
+    let splitter = Regex::new(r#"\W"#).unwrap();
+    let mut uniques: HashSet<String> = HashSet::new();
+    let mut result: Vec<String> = Vec::new();
+    for input in inputs {
+        let words: Vec<String> = splitter
+            .replace_all(*input, " ")
+            .split(' ')
+            .filter(|w| w.len() > 3)
+            .map(|w| w.to_lowercase())
+            .collect();
+        for word in words {
+            if !uniques.contains(&word) {
+                uniques.insert(word.clone());
+                result.push(word);
+            }
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    pub fn splits_user_inputs() {
+        let user_inputs = &["Peter Zingg", "peter.zingg@gmail.com"];
+        let result = split_inputs(user_inputs);
+        assert_eq!(result.len(), 3);
+        assert_eq!(result, vec!["peter", "zingg", "gmail"])
     }
 }

--- a/jelly/src/forms/password.rs
+++ b/jelly/src/forms/password.rs
@@ -1,10 +1,11 @@
+use std::collections::HashSet;
+use std::fmt;
+#[allow(unused_imports)]
+use std::hash::Hash;
+use std::ops::Deref;
 use fancy_regex::Regex;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Deserializer, Serialize};
-use std::collections::HashSet;
-use std::fmt;
-use std::hash::Hash;
-use std::ops::Deref;
 use zxcvbn::zxcvbn;
 
 use super::validation::{concat_results, Validatable, Validation, ValidationError, ValidationErrors, Validator};
@@ -33,6 +34,7 @@ impl PasswordField {
     }
 
     pub fn validate_with(&self, user_inputs: &[&str], cfg: &PasswordPolicy) -> Result<(), ValidationErrors<String>> {
+        // This returns if value is empty
         let _ok = self.validate()?;
 
         let length_validation = match &cfg.length {
@@ -170,7 +172,11 @@ impl Validatable<String> for PasswordField {
     }
 }
 
-
+/// Part of the [`PasswordPolicy`] that determines validity
+/// for new passwords. [`pattern`] is the regex that the
+/// password must match, and [`message`] is the user-facing
+/// error message that will be presented if the password does
+/// match the regex.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RegexConfig {
     pattern: String,
@@ -187,10 +193,15 @@ impl RegexConfig {
 }
 
 lazy_static! {
+    /// A [`RegexConfig`] for any combination of alphanumerics and hyphens.
     pub static ref REGEX_ANH: RegexConfig = RegexConfig::new(
         r#"^[-a-zA-Z0-9]+$"#,
         "can only contain uppercase, lowercase, numbers, and hyphens."
     );
+
+    /// A [`RegexConfig`] that requires at least one of uppercase, lowercase,
+    /// number, and symbol. We use the `fancy_regex` crate, which can handle
+    /// `?=` positive lookahead (non-capturing) groups.
     pub static ref REGEX_ULNS: RegexConfig = RegexConfig::new(
         r#"^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[-_.@#$%^&*!?])[-_.@#$%^&*!?a-zA-Z0-9]+$"#,
         "must contain at least one each of uppercase, lowercase, number, and symbol from this set: -_@#$%^&*!?."
@@ -203,6 +214,8 @@ impl Default for RegexConfig {
     }
 }
 
+/// The mininum score of password attackability, as determined
+/// by the `zxcvbn` algorithm.
 #[repr(u8)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum PasswordScore {
@@ -213,6 +226,19 @@ pub enum PasswordScore {
     VeryUnguessable = 4,   // strong protection from offline slow-hash scenario. (guesses >= 10^10)
 }
 
+/// Besides being required, you can set three more
+/// validations on new passwords, by setting these fields
+/// to a `Some` value:
+///
+/// * [`length`]:   Some((min_length, max_length))
+/// * [`regex`]:    Some(regex_config) -- see the description and two
+///    predefined statics for the [`RegexConfig`] struct
+/// * [`strength`]: Some(min_password_score) -- see the description for
+///    the [`PasswordScore`] enum. Usually you want a minimum score
+///    of SafelyUnguessable
+///
+/// If any of these are set to a Some value, the password
+/// will be validated against the optional argument.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PasswordPolicy {
     length: Option<(usize, usize)>,
@@ -230,9 +256,22 @@ impl Default for PasswordPolicy {
     }
 }
 
-// DONE: removes all "non-word" chars,
-// DONE: removes words 3 chars or shorter
-// DONE: removes duplicates
+/// Pulls out non-duplicated words of four or more characters
+/// from a list of inputs. Words are converted to lowercase
+/// before testing for duplicates. The results are used
+/// to seed the `zxcvbn` dictionary, when determining whether
+/// a submitted password is too similar to components of a user's
+/// name or email address.
+///
+/// Example:
+///
+/// ```rust
+/// use jelly::forms::split_inputs;
+///
+/// let user_inputs = &["Jeffry A Bezos", "jbezos@amazon.com"];
+/// let result = split_inputs(user_inputs);
+/// assert_eq!(result, vec!["jeffry", "bezos", "jbezos", "amazon"])
+/// ```
 pub fn split_inputs(inputs: &[&str]) -> Vec<String> {
     let splitter = Regex::new(r#"\W"#).unwrap();
     let mut uniques: HashSet<String> = HashSet::new();
@@ -252,17 +291,4 @@ pub fn split_inputs(inputs: &[&str]) -> Vec<String> {
         }
     }
     result
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    pub fn splits_user_inputs() {
-        let user_inputs = &["Peter Zingg", "peter.zingg@gmail.com"];
-        let result = split_inputs(user_inputs);
-        assert_eq!(result.len(), 3);
-        assert_eq!(result, vec!["peter", "zingg", "gmail"])
-    }
 }

--- a/jelly/src/forms/validators.rs
+++ b/jelly/src/forms/validators.rs
@@ -1,0 +1,25 @@
+use uuid::Uuid;
+
+use super::validation::{ValidationError, ValidationErrors};
+
+/// Just checks that key is present. Should be placed on every field.
+pub fn required_key<Value>(_value: &Value, key: &String) -> Result<(), ValidationErrors<String>> {
+  if key.is_empty() {
+      Err(ValidationError::new(Uuid::new_v4().to_hyphenated().to_string(), "REQUIRED_KEY")
+          .with_message(|_| "must have a unique key".to_owned())
+          .into())
+  } else {
+      Ok(())
+  }
+}
+
+/// Just checks that key is present. Should be placed on every field.
+pub fn required_value(value: &String, key: &String) -> Result<(), ValidationErrors<String>> {
+    if value.is_empty() {
+        Err(ValidationError::new(key.clone(), "REQUIRED_VALUE")
+            .with_message(|_| "cannot be blank".to_owned())
+            .into())
+    } else {
+        Ok(())
+    }
+}

--- a/jelly/src/oauth/client.rs
+++ b/jelly/src/oauth/client.rs
@@ -71,7 +71,7 @@ pub fn client_for(provider: &str) -> Option<ScopedClient> {
             let root_domain = env::var("JELLY_DOMAIN").expect("JELLY_DOMAIN not set!");
             // Important: the redirect_uri must have the trailing slash,
             // and it must be registered with the OAuth provider.
-            let redirect_uri = format!("{}/oauth/callback/", root_domain);
+            let redirect_uri = format!("{}/oauth/callback", root_domain);
             let client = build_client(provider, &redirect_uri);
             provider_map.insert(provider.to_string(), client);
         }

--- a/jelly/src/prelude.rs
+++ b/jelly/src/prelude.rs
@@ -10,7 +10,7 @@ pub use super::{
 
     // A trait used for calling validate() on form field types. Your form(s) can also implement
     // this, so it's exported here for ease of use.
-    forms::Validation,
+    //forms::validations::Validatable,
 
     // A string that is stored as jsonb in the database, keyed for locales.
     //i18n::{I18nString},

--- a/src/accounts/forms.rs
+++ b/src/accounts/forms.rs
@@ -1,4 +1,5 @@
-use jelly::forms::{EmailField, PasswordConfig, PasswordField, TextField, Validation};
+use jelly::forms::{EmailField, PasswordPolicy, PasswordField, TextField};
+use jelly::forms::validation::{concat_results, Validatable, ValidationErrors};
 use serde::{Deserialize, Serialize};
 
 fn default_redirect_path() -> String {
@@ -8,32 +9,50 @@ fn default_redirect_path() -> String {
 #[derive(Default, Debug, Deserialize, Serialize)]
 pub struct LoginForm {
     pub email: EmailField,
-    pub password: PasswordField,
-
+    pub password: TextField, // not checking strength, just presence
     #[serde(default = "default_redirect_path")]
     pub redirect: String,
 }
 
-impl Validation for LoginForm {
-    fn is_valid(&mut self) -> bool {
-        self.email.is_valid() && !self.password.value.is_empty()
+impl LoginForm {
+    pub fn set_keys(mut self) -> Self {
+        self.email = self.email.with_key("email");
+        self.password = self.password.with_key("password");
+        self
+    }
+}
+
+impl Validatable<String> for LoginForm {
+    fn validate(&self) -> Result<(), ValidationErrors<String>> {
+        concat_results(vec![self.email.validate(), self.password.validate()])
     }
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct NewAccountForm {
+    #[serde(skip)]
+    pub policy: PasswordPolicy,
     pub name: TextField,
     pub email: EmailField,
     pub password: PasswordField,
 }
 
-impl Validation for NewAccountForm {
-    fn is_valid(&mut self) -> bool {
-        self.name.is_valid()
-            && self.email.is_valid()
-            && self
-                .password
-                .validate_with(&[&self.name, &self.email], &PasswordConfig::default())
+impl NewAccountForm {
+    pub fn set_keys(mut self) -> Self {
+        self.name = self.name.with_key("name");
+        self.email = self.email.with_key("email");
+        self.password = self.password.with_key("password");
+        self
+    }
+}
+
+impl Validatable<String> for NewAccountForm {
+    fn validate(&self) -> Result<(), ValidationErrors<String>> {
+        concat_results(vec![
+            self.name.validate(),
+            self.email.validate(),
+            self.password.validate_with(&[&self.name, &self.email], &self.policy)
+        ])
     }
 }
 
@@ -42,9 +61,16 @@ pub struct EmailForm {
     pub email: EmailField,
 }
 
-impl Validation for EmailForm {
-    fn is_valid(&mut self) -> bool {
-        self.email.is_valid()
+impl EmailForm {
+    pub fn set_keys(mut self) -> Self {
+        self.email = self.email.with_key("email");
+        self
+    }
+}
+
+impl Validatable<String> for EmailForm {
+    fn validate(&self) -> Result<(), ValidationErrors<String>> {
+        self.email.validate()
     }
 }
 
@@ -59,22 +85,32 @@ pub struct ChangePasswordForm {
     pub password_confirm: PasswordField,
 }
 
-impl Validation for ChangePasswordForm {
-    fn is_valid(&mut self) -> bool {
-        if !self.password.is_valid() || !self.password_confirm.is_valid() {
-            return false;
-        }
+impl ChangePasswordForm {
+    pub fn set_keys(mut self) -> Self {
+        self.password = self.password.with_key("password");
+        self.password_confirm = self.password_confirm.with_key("password_confirm");
+        self
+    }
 
-        if self.password.value != self.password_confirm.value {
-            self.password
-                .errors
-                .push("Passwords must match.".to_string());
-            return false;
-        }
+    pub fn set_name_and_email(mut self, name: &str, email: &str) -> Self {
+        self.name = Some(name.to_owned());
+        self.email = Some(email.to_owned());
+        self
+    }
+}
 
-        self.password.validate_with(
-            &[self.name.as_ref().unwrap(), self.email.as_ref().unwrap()],
-            &PasswordConfig::default(),
-        )
+impl Validatable<String> for ChangePasswordForm {
+    fn validate(&self) -> Result<(), ValidationErrors<String>> {
+        let mut inputs: Vec<&str> = Vec::new();
+        if let Some(name) = &self.name {
+            inputs.push(name);
+        }
+        if let Some(email) = &self.email {
+            inputs.push(email);
+        }
+        concat_results(vec![
+            self.password.validate_with(&inputs, &PasswordPolicy::default()),
+            self.password_confirm.validate_confirmation(&self.password.value)
+        ])
     }
 }

--- a/src/accounts/views/login.rs
+++ b/src/accounts/views/login.rs
@@ -1,4 +1,5 @@
 use jelly::actix_web::{web, HttpRequest};
+use jelly::forms::validation::{Validatable};
 use jelly::prelude::*;
 use jelly::request::{Authentication, DatabasePool};
 use jelly::Result;
@@ -27,12 +28,11 @@ pub async fn authenticate(
     if request.is_authenticated()? {
         return request.redirect("/dashboard");
     }
-
-    let mut form = form.into_inner();
-    if !form.is_valid() {
+    let form = form.into_inner().set_keys();
+    if let Err(errors) = form.validate() {
         return request.render(400, "accounts/login.html", {
             let mut context = Context::new();
-            context.insert("error", "Invalid email or password.");
+            context.insert("error", &errors);
             context.insert("form", &form);
             context
         });

--- a/src/accounts/views/register.rs
+++ b/src/accounts/views/register.rs
@@ -1,4 +1,5 @@
 use jelly::actix_web::{web, HttpRequest};
+use jelly::forms::validation::{Validatable};
 use jelly::prelude::*;
 use jelly::request::{Authentication, DatabasePool};
 use jelly::Result;
@@ -26,11 +27,12 @@ pub async fn create_account(
     if request.is_authenticated()? {
         return request.redirect("/dashboard");
     }
-
-    let mut form = form.into_inner();
-    if !form.is_valid() {
+    // Will use default password policy
+    let form = form.into_inner().set_keys();
+    if let Err(errors) = form.validate() {
         return request.render(400, "accounts/register.html", {
             let mut ctx = Context::new();
+            ctx.insert("errors", &errors);
             ctx.insert("form", &form);
             ctx
         });
@@ -57,5 +59,5 @@ pub async fn create_account(
     }
 
     // No matter what, just appear as if it worked.
-    request.redirect("/accounts/verify/")
+    request.redirect("/accounts/verify")
 }

--- a/src/accounts/views/register.rs
+++ b/src/accounts/views/register.rs
@@ -31,10 +31,12 @@ pub async fn create_account(
     let form = form.into_inner().set_keys();
     if let Err(errors) = form.validate() {
         return request.render(400, "accounts/register.html", {
-            let mut ctx = Context::new();
-            ctx.insert("errors", &errors);
-            ctx.insert("form", &form);
-            ctx
+            let mut context = Context::new();
+
+            // ValidationErrors object is serialized into HashMap here
+            context.insert("errors", &errors);
+            context.insert("form", &form);
+            context
         });
     }
 

--- a/src/accounts/views/reset_password.rs
+++ b/src/accounts/views/reset_password.rs
@@ -27,6 +27,8 @@ pub async fn request_reset(request: HttpRequest, form: web::Form<EmailForm>) -> 
     if let Err(errors) = form.validate() {
         return request.render(400, "accounts/reset_password/index.html", {
             let mut context = Context::new();
+
+            // ValidationErrors object is serialized into HashMap here
             context.insert("errors", &errors);
             context.insert("form", &form);
             context.insert("sent", &false);
@@ -89,6 +91,8 @@ pub async fn reset(
             if let Err(errors) = form.validate() {
                 return request.render(200, "accounts/reset_password/change_password.html", {
                     let mut context = Context::new();
+
+                    // ValidationErrors object is serialized into HashMap here
                     context.insert("errors", &errors);
                     context.insert("form", &form);
                     context

--- a/src/oauth/views/authorize.rs
+++ b/src/oauth/views/authorize.rs
@@ -45,6 +45,8 @@ pub async fn confirm_identity(
     if let Err(errors) = form.validate() {
         return request.render(400, "oauth/confirm.html", {
             let mut context = Context::new();
+
+            // ValidationErrors object is serialized into HashMap here
             context.insert("errors", &errors);
             context.insert("form", &form);
             context
@@ -67,11 +69,14 @@ pub async fn confirm_identity(
         return request.redirect("/dashboard");
     }
 
+    // Create a ValidationErrors object
     let errors: ValidationErrors<String> = ValidationError::new("email".to_owned(), "EMAIL_IS_OTHER_ACCOUNT")
         .with_message(move |_| "address is assigned to another account".to_owned())
         .into();
     request.render(400, "oauth/confirm.html", {
         let mut context = Context::new();
+
+        // ValidationErrors object is serialized into HashMap here
         context.insert("errors", &errors);
         context.insert("form", &form);
         context

--- a/src/oauth/views/authorize.rs
+++ b/src/oauth/views/authorize.rs
@@ -1,10 +1,11 @@
+use jelly::{oauth, Result, SESSION_OAUTH_FLOW, SESSION_OAUTH_TOKEN};
 use jelly::actix_session::Session;
 use jelly::actix_web::web;
 use jelly::error::OAuthError;
 use jelly::forms::{EmailField, TextField};
+use jelly::forms::validation::{Validatable, ValidationError, ValidationErrors};
 use jelly::oauth::{ClientFlow, OAuthFlow, UserInfo};
 use jelly::prelude::*;
-use jelly::{oauth, Result, SESSION_OAUTH_FLOW, SESSION_OAUTH_TOKEN};
 use serde::{Deserialize, Serialize};
 use std::{result, str};
 
@@ -40,12 +41,11 @@ pub async fn confirm_identity(
     request: HttpRequest,
     form: web::Form<LinkIdentityForm>,
 ) -> Result<HttpResponse> {
-    let mut form = form.into_inner();
-
-    if !form.is_valid() {
+    let form = form.into_inner().set_keys();
+    if let Err(errors) = form.validate() {
         return request.render(400, "oauth/confirm.html", {
             let mut context = Context::new();
-            context.insert("error", "Invalid email.");
+            context.insert("errors", &errors);
             context.insert("form", &form);
             context
         });
@@ -67,9 +67,12 @@ pub async fn confirm_identity(
         return request.redirect("/dashboard");
     }
 
+    let errors: ValidationErrors<String> = ValidationError::new("email".to_owned(), "EMAIL_IS_OTHER_ACCOUNT")
+        .with_message(move |_| "address is assigned to another account".to_owned())
+        .into();
     request.render(400, "oauth/confirm.html", {
         let mut context = Context::new();
-        context.insert("error", "Invalid email.");
+        context.insert("errors", &errors);
         context.insert("form", &form);
         context
     })

--- a/src/oauth/views/login.rs
+++ b/src/oauth/views/login.rs
@@ -1,5 +1,6 @@
 use jelly::actix_web::web;
 use jelly::error::OAuthError;
+use jelly::forms::validation::{Validatable};
 use jelly::oauth;
 use jelly::prelude::*;
 use jelly::Result;
@@ -33,12 +34,11 @@ pub async fn authenticate(
     if request.is_authenticated()? {
         return request.redirect("/dashboard");
     }
-
-    let mut form = form.into_inner();
-    if !form.is_valid() {
+    let form = form.into_inner().set_keys();
+    if let Err(errors) = form.validate() {
         return request.render(400, "oauth/login.html", {
             let mut context = Context::new();
-            context.insert("error", "Invalid email.");
+            context.insert("errors", &errors);
             context.insert("form", &form);
             context
         });

--- a/src/oauth/views/login.rs
+++ b/src/oauth/views/login.rs
@@ -38,6 +38,8 @@ pub async fn authenticate(
     if let Err(errors) = form.validate() {
         return request.render(400, "oauth/login.html", {
             let mut context = Context::new();
+
+            // ValidationErrors object is serialized into HashMap here
             context.insert("errors", &errors);
             context.insert("form", &form);
             context

--- a/templates/accounts/login.html
+++ b/templates/accounts/login.html
@@ -6,23 +6,26 @@
 <h1>Login with password</h1>
 
 <form action="/accounts/login" method="POST" id="loginform">
-    {% if error %}
-    <ul>
-        <li>&#9432;&nbsp; {{ error }}</li>
-    </ul>
-    {% endif %}
-
     <p>
         <label for="email">Email:</label>
         <input name="email" type="email" value="{{ form.email.value }}">
+        {% if errors and errors is containing("email") %}
+        {% for e in errors["email"] %}
+            <span>{{ e["message"] }}</span>
+        {% endfor %}
+        {% endif %}
     </p>
-
     <p>
         <label for="password">Password:</label>
         <input name="password" type="password">
+        {% if errors and errors is containing("password") %}
+        {% for e in errors["password"] %}
+            <span>{{ e["message"] }}</span>
+        {% endfor %}
+        {% endif %}
+
         <a href="/accounts/reset" title="Reset Your Password">Forgot your password?</a>
     </p>
-
     <button type="submit">Login</button>
 </form>
 

--- a/templates/accounts/register.html
+++ b/templates/accounts/register.html
@@ -5,37 +5,32 @@
 {% block content %}
 <h1>Sign Up</h1>
 
-{% if error %}
-<ul>
-    <li>&#9432;&nbsp; {{ error }}</li>
-</ul>
-{% endif %}
-
 <form action="/accounts/register" method="POST">
     <p>
         <label for="name">Your Name:</label>
         <input type="text" name="name" value="{{ form.name.value }}">
-        {% if form.name.errors | length > 0 %}
-            {{ form.name.errors }}
+        {% if errors and errors is containing("name") %}
+        {% for e in errors["name"] %}
+            <span>{{ e["message"] }}</span>
+        {% endfor %}
         {% endif %}
     </p>
-
     <p>
         <label for="email">Email:</label>
         <input name="email" type="email" value="{{ form.email.value }}">
-        {% if form.email.errors | length > 0 %}
-            {{ form.email.errors }}
+        {% if errors and errors is containing("email") %}
+        {% for e in errors["email"] %}
+            <span>{{ e["message"] }}</span>
+        {% endfor %}
         {% endif %}
     </p>
-
     <p>
         <label for="password">Password:</label>
         <input name="password" type="password">
-        {% if form.password.errors | length > 0 %}
-            {{ form.password.errors }}
-        {% endif %}
-        {% if form.password.hints | length > 0 %}
-            {{ form.password.hints }}
+        {% if errors and errors is containing("password") %}
+        {% for e in errors["password"] %}
+            <span>{{ e["message"] }}</span>
+        {% endfor %}
         {% endif %}
     </p>
 

--- a/templates/oauth/confirm.html
+++ b/templates/oauth/confirm.html
@@ -11,19 +11,23 @@
 </p>
 
 <form action="/oauth/confirm" method="POST" id="linkform">
-    {% if error %}
-    <ul>
-        <li>&#9432;&nbsp; {{ error }}</li>
-    </ul>
-    {% endif %}
-
     <p>
         <label for="name">Name:</label>
         <input name="name" type="text" value="{{ form.name.value }}">
+        {% if errors and errors is containing("name") %}
+        {% for e in errors["name"] %}
+            <span>{{ e["message"] }}</span>
+        {% endfor %}
+        {% endif %}
     </p>
     <p>
         <label for="email">Email:</label>
         <input name="email" type="email" value="{{ form.email.value }}">
+        {% if errors and errors is containing("email") %}
+        {% for e in errors["email"] %}
+            <span>{{ e["message"] }}</span>
+        {% endfor %}
+        {% endif %}
     </p>
 
     <input name="provider" type="hidden" value="{{ form.provider }}">

--- a/templates/oauth/login.html
+++ b/templates/oauth/login.html
@@ -15,16 +15,15 @@
 </p>
 
 <form action="/oauth/login" method="POST" id="loginform">
-    {% if error %}
-    <ul>
-        <li>&#9432;&nbsp; {{ error }}</li>
-    </ul>
-    {% endif %}
-
     {% if form.email_hint %}
     <p>
         <label for="email">Email:</label>
         <input name="email" type="email" value="{{ form.email.value }}">
+        {% if errors and errors is containing("email") %}
+        {% for e in errors["email"] %}
+            <span>{{ e["message"] }}</span>
+        {% endfor %}
+        {% endif %}
     </p>
     {% else %}
     <input name="email" type="hidden" value="">


### PR DESCRIPTION
1. Found and modified the form-validation crate to implement Serialize trait on the ValidationErrors struct.
2. Replaced validate method to the signature from the form-validation Validatable trait.
3. Put ValidationErrors into Tera context.
4. Render errors in HTML templates.
5. Minor changes in PasswordField validation.
6. Added docs and doc tests.